### PR TITLE
DEBITO_SALDO

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -48,6 +48,7 @@ public class TicketMachine {
         String result = "*****************\n";
         result += "*** R$ " + saldo + ",00 ****\n";
         result += "*****************\n";
+        saldo -= valor;
         return result;
     }
 }


### PR DESCRIPTION
Refere-se ao problema de saldo, em que após a impressão do bilhete, o saldo disponível não era dimunuído. Feita a correção.