### PR TITLE
CEDULA_INVALIDA

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -31,7 +31,7 @@ public class TicketMachine {
             }
         }
         if (!achou) {
-            throw new PapelMoedaInvalidaException();
+            throw new PapelMoedaInvalidaException("Cédula inválida: " + quantia);
         }
         this.saldo += quantia;
     }

--- a/Source Code Inspection/src/br/calebe/ticketmachine/exception/PapelMoedaInvalidaException.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/exception/PapelMoedaInvalidaException.java
@@ -5,5 +5,11 @@ package exception;
  * @author Calebe de Paula Bianchini
  */
 public class PapelMoedaInvalidaException extends Exception {
-    
+    public PapelMoedaInvalidaException() {
+        super("Cédula inválida!");  // Mensagem padrão
+    }
+
+    public PapelMoedaInvalidaException(String message) {
+        super(message);  // Permite passar uma mensagem personalizada
+    }
 }


### PR DESCRIPTION
Correção da mensagem de cédula inválida, que antes era somente lancaçado um erro. agora foi implementado na função de excessão.